### PR TITLE
consider nodejs 20 environment

### DIFF
--- a/src/setup.ts
+++ b/src/setup.ts
@@ -12,7 +12,15 @@ Object.assign(globalThis, {
   addEventListener,
   CompressionStream,
   DecompressionStream,
-  crypto,
   fetch,
   fastly,
 });
+
+// Since nodejs 20.0 has globalThis.crypto as default, compartible with WebCrypto,
+// so we should not polyfill it in order to avoid overwrite error.
+if ("crypto" in globalThis) {
+  (globalThis as any).__fastlyComputeNodeDefaultCrypto = true;
+} else {
+  // Otherwise, need polyfill
+  Object.assign(globalThis, { crypto });
+}

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -19,6 +19,7 @@ Object.assign(globalThis, {
 // Since nodejs 20.0 has globalThis.crypto as default, compartible with WebCrypto,
 // so we should not polyfill it in order to avoid overwrite error.
 if ("crypto" in globalThis) {
+  // biome-ignore lint/suspicious/noExplicitAny: access to global
   (globalThis as any).__fastlyComputeNodeDefaultCrypto = true;
 } else {
   // Otherwise, need polyfill

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,9 @@
     "skipLibCheck": true,
     "declaration": true
   },
+  "files": [
+    "types/global.d.ts"
+  ],
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "src/**/*.test.ts"]
 }

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,0 +1,3 @@
+declare global {
+  var __fastlyComputeNodeDefaultCrypto: boolean;
+}


### PR DESCRIPTION
Consideration of https://github.com/ysugimoto/vite-plugin-fastly-js-compute/issues/1

In nodejs 20+, `globalThis.crypto` exists as default so we could not polyfill.
This PR will fix this problem, add `globalThis.__fastlyComputeNodeDefaultCrypto` flag as `true` instead in order to skip some tests.